### PR TITLE
Uses new puppetlabs/apt syntax

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,12 @@ class erlang::params {
 
   case $::osfamily {
     'Debian' : {
+      $os                       = downcase($::operatingsystem)
       $key_signature            = '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA'
       $package_name             = 'erlang-nox'
       $local_repo_location      = undef
-      $remote_repo_key_location = 'http://packages.erlang-solutions.com/debian/erlang_solutions.asc'
-      $remote_repo_location     = 'http://packages.erlang-solutions.com/debian'
+      $remote_repo_key_location = "http://packages.erlang-solutions.com/${os}/erlang_solutions.asc"
+      $remote_repo_location     = "http://packages.erlang-solutions.com/${os}"
       $repos                    = 'contrib'
     }
     'RedHat', 'SUSE', 'Archlinux' : {

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -30,12 +30,16 @@ class erlang::repo::apt(
 
   Class['erlang::repo::apt'] -> Package<| title == $package_name |>
 
-  apt::source { 'erlang':
-    include_src => false,
-    key         => $key_signature,
-    key_source  => $remote_repo_key_location,
-    location    => $remote_repo_location,
-    repos       => $repos,
+  ::apt::source { 'erlang':
+    include           => { 'src' => false },
+    key               => {
+      'id'     => $key_signature,
+      'server' => 'hkp://keyserver.ubuntu.com:80',
+      'source' => $remote_repo_key_location,
+    },
+    location          => $remote_repo_location,
+    release           => $::lsbdistcodename,
+    repos             => $repos,
   }
 
 }


### PR DESCRIPTION
As PR'ed into upstream, in https://github.com/garethr/garethr-erlang/pull/31/files
Upstream seems to be stale (last commit >2 years ago!)

Since we bumped puppetlabs/apt in https://github.com/BrandwatchLtd/puppetserver-environments/pull/2022 the erlang module is broken and makes puppet agent fail.

This fixes the issue in our fork of the upstream https://github.com/garethr/garethr-erlang
Further changes in our Puppetfile to reference this fork are needed